### PR TITLE
Add explicit dependency to sortable.ts

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,5 @@
+import "./sortable";
+
 export function configure(config) {
   config.globalResources("./sortable");
 }


### PR DESCRIPTION
When bundling a package, the static tree analysis does not see the dependency to sortable.ts, and the plugin fails to load.